### PR TITLE
Implement and enhance localization settings management and UI

### DIFF
--- a/app/Filament/Admin/Pages/LocalizationSettings.php
+++ b/app/Filament/Admin/Pages/LocalizationSettings.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Filament\Admin\Pages;
+
+use App\Filament\Pages\SettingsPage;
+use App\Settings\LocalizationSettings as LocalizationSettingsData;
+use BackedEnum;
+use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+
+class LocalizationSettings extends SettingsPage
+{
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedLanguage;
+
+    protected static ?int $navigationSort = 2;
+
+    protected static string $settings = LocalizationSettingsData::class;
+
+    public static function getNavigationLabel(): string
+    {
+        return __('Localization');
+    }
+
+    public function getTitle(): string
+    {
+        return __('Localization Settings');
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->columns(1)->components([
+            Section::make(__('Languages'))
+                ->description(__('Choose which languages visitors can switch between. With only one language on, the language selector is hidden.'))
+                ->icon(Heroicon::OutlinedLanguage)
+                ->iconColor('info')
+                ->schema([
+                    CheckboxList::make('enabled_locales')
+                        ->label(__('Available languages'))
+                        ->extraAttributes(['data-testid' => 'admin-enabled-locales'])
+                        ->options(fn (): array => app(LocalizationSettingsData::class)->available())
+                        ->helperText(__('Only languages with translation files installed are listed.'))
+                        ->required()
+                        ->minItems(1)
+                        ->live()
+                        ->columns(2)
+                        ->columnSpanFull(),
+                    Select::make('default_locale')
+                        ->label(__('Default language'))
+                        ->extraAttributes(['data-testid' => 'admin-default-locale'])
+                        // Sourced from what is currently ticked, so the default can never
+                        // be a language the application no longer offers.
+                        ->options(fn (Get $get): array => array_intersect_key(
+                            app(LocalizationSettingsData::class)->available(),
+                            array_flip((array) $get('enabled_locales')),
+                        ))
+                        ->helperText(__('Used until a visitor picks a language of their own.'))
+                        ->required()
+                        ->native(false)
+                        ->columnSpanFull(),
+                ]),
+        ]);
+    }
+}

--- a/app/Filament/Admin/Pages/LocalizationSettings.php
+++ b/app/Filament/Admin/Pages/LocalizationSettings.php
@@ -51,8 +51,6 @@ class LocalizationSettings extends SettingsPage
                     Select::make('default_locale')
                         ->label(__('Default language'))
                         ->extraAttributes(['data-testid' => 'admin-default-locale'])
-                        // Sourced from what is currently ticked, so the default can never
-                        // be a language the application no longer offers.
                         ->options(fn (Get $get): array => array_intersect_key(
                             app(LocalizationSettingsData::class)->available(),
                             array_flip((array) $get('enabled_locales')),

--- a/app/Filament/Admin/Pages/LocalizationSettings.php
+++ b/app/Filament/Admin/Pages/LocalizationSettings.php
@@ -5,10 +5,8 @@ namespace App\Filament\Admin\Pages;
 use App\Filament\Pages\SettingsPage;
 use App\Settings\LocalizationSettings as LocalizationSettingsData;
 use BackedEnum;
-use Closure;
+use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\Select;
-use Filament\Forms\Components\Toggle;
-use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
@@ -40,93 +38,30 @@ class LocalizationSettings extends SettingsPage
                 ->icon(Heroicon::OutlinedLanguage)
                 ->iconColor('info')
                 ->schema([
-                    Grid::make(2)
-                        ->schema($this->localeToggles())
+                    CheckboxList::make('enabled_locales')
+                        ->label(__('Available languages'))
+                        ->extraAttributes(['data-testid' => 'admin-enabled-locales'])
+                        ->options(fn (): array => app(LocalizationSettingsData::class)->available())
+                        ->helperText(__('Only languages with translation files installed are listed.'))
+                        ->required()
+                        ->minItems(1)
+                        ->live()
+                        ->columns(2)
                         ->columnSpanFull(),
                     Select::make('default_locale')
                         ->label(__('Default language'))
                         ->extraAttributes(['data-testid' => 'admin-default-locale'])
-                        // Sourced from what is currently toggled on, so the default can
-                        // never be a language the application no longer offers.
+                        // Sourced from what is currently ticked, so the default can never
+                        // be a language the application no longer offers.
                         ->options(fn (Get $get): array => array_intersect_key(
                             app(LocalizationSettingsData::class)->available(),
-                            $this->enabledFromFormState($get),
+                            array_flip((array) $get('enabled_locales')),
                         ))
                         ->helperText(__('Used until a visitor picks a language of their own.'))
                         ->required()
                         ->native(false)
-                        // The only field that can carry this message: toggles have no
-                        // group to hang it on, and turning every language off would leave
-                        // the application rendering raw translation keys.
-                        ->rule(fn (Get $get): Closure => function (string $attribute, mixed $value, Closure $fail) use ($get): void {
-                            if ($this->enabledFromFormState($get) === []) {
-                                $fail(__('At least one language must be enabled.'));
-                            }
-                        })
                         ->columnSpanFull(),
                 ]),
         ]);
-    }
-
-    /**
-     * One toggle per installed language, matching how every other settings page here
-     * renders a boolean.
-     *
-     * @return list<Toggle>
-     */
-    private function localeToggles(): array
-    {
-        $toggles = [];
-
-        foreach (app(LocalizationSettingsData::class)->available() as $code => $name) {
-            $toggles[] = Toggle::make("enabled_locales.{$code}")
-                ->label($name)
-                ->extraAttributes(['data-testid' => "admin-locale-{$code}"])
-                ->live();
-        }
-
-        return $toggles;
-    }
-
-    /**
-     * The languages currently switched on in the form, as a code-keyed array.
-     *
-     * @return array<string, true>
-     */
-    private function enabledFromFormState(Get $get): array
-    {
-        return array_filter((array) $get('enabled_locales'));
-    }
-
-    /**
-     * The setting stores a list of codes, because that is what the application asks it
-     * for. A toggle per language needs a code-keyed map of booleans, so the two shapes are
-     * translated here at the form boundary rather than distorting either side.
-     *
-     * @param  array<string, mixed>  $data
-     * @return array<string, mixed>
-     */
-    protected function mutateFormDataBeforeFill(array $data): array
-    {
-        $enabled = (array) ($data['enabled_locales'] ?? []);
-
-        $data['enabled_locales'] = [];
-
-        foreach (array_keys(app(LocalizationSettingsData::class)->available()) as $code) {
-            $data['enabled_locales'][$code] = in_array($code, $enabled, true);
-        }
-
-        return $data;
-    }
-
-    /**
-     * @param  array<string, mixed>  $data
-     * @return array<string, mixed>
-     */
-    protected function mutateFormDataBeforeSave(array $data): array
-    {
-        $data['enabled_locales'] = array_keys(array_filter((array) ($data['enabled_locales'] ?? [])));
-
-        return $data;
     }
 }

--- a/app/Filament/Admin/Pages/LocalizationSettings.php
+++ b/app/Filament/Admin/Pages/LocalizationSettings.php
@@ -5,8 +5,10 @@ namespace App\Filament\Admin\Pages;
 use App\Filament\Pages\SettingsPage;
 use App\Settings\LocalizationSettings as LocalizationSettingsData;
 use BackedEnum;
-use Filament\Forms\Components\CheckboxList;
+use Closure;
 use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
@@ -38,30 +40,93 @@ class LocalizationSettings extends SettingsPage
                 ->icon(Heroicon::OutlinedLanguage)
                 ->iconColor('info')
                 ->schema([
-                    CheckboxList::make('enabled_locales')
-                        ->label(__('Available languages'))
-                        ->extraAttributes(['data-testid' => 'admin-enabled-locales'])
-                        ->options(fn (): array => app(LocalizationSettingsData::class)->available())
-                        ->helperText(__('Only languages with translation files installed are listed.'))
-                        ->required()
-                        ->minItems(1)
-                        ->live()
-                        ->columns(2)
+                    Grid::make(2)
+                        ->schema($this->localeToggles())
                         ->columnSpanFull(),
                     Select::make('default_locale')
                         ->label(__('Default language'))
                         ->extraAttributes(['data-testid' => 'admin-default-locale'])
-                        // Sourced from what is currently ticked, so the default can never
-                        // be a language the application no longer offers.
+                        // Sourced from what is currently toggled on, so the default can
+                        // never be a language the application no longer offers.
                         ->options(fn (Get $get): array => array_intersect_key(
                             app(LocalizationSettingsData::class)->available(),
-                            array_flip((array) $get('enabled_locales')),
+                            $this->enabledFromFormState($get),
                         ))
                         ->helperText(__('Used until a visitor picks a language of their own.'))
                         ->required()
                         ->native(false)
+                        // The only field that can carry this message: toggles have no
+                        // group to hang it on, and turning every language off would leave
+                        // the application rendering raw translation keys.
+                        ->rule(fn (Get $get): Closure => function (string $attribute, mixed $value, Closure $fail) use ($get): void {
+                            if ($this->enabledFromFormState($get) === []) {
+                                $fail(__('At least one language must be enabled.'));
+                            }
+                        })
                         ->columnSpanFull(),
                 ]),
         ]);
+    }
+
+    /**
+     * One toggle per installed language, matching how every other settings page here
+     * renders a boolean.
+     *
+     * @return list<Toggle>
+     */
+    private function localeToggles(): array
+    {
+        $toggles = [];
+
+        foreach (app(LocalizationSettingsData::class)->available() as $code => $name) {
+            $toggles[] = Toggle::make("enabled_locales.{$code}")
+                ->label($name)
+                ->extraAttributes(['data-testid' => "admin-locale-{$code}"])
+                ->live();
+        }
+
+        return $toggles;
+    }
+
+    /**
+     * The languages currently switched on in the form, as a code-keyed array.
+     *
+     * @return array<string, true>
+     */
+    private function enabledFromFormState(Get $get): array
+    {
+        return array_filter((array) $get('enabled_locales'));
+    }
+
+    /**
+     * The setting stores a list of codes, because that is what the application asks it
+     * for. A toggle per language needs a code-keyed map of booleans, so the two shapes are
+     * translated here at the form boundary rather than distorting either side.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        $enabled = (array) ($data['enabled_locales'] ?? []);
+
+        $data['enabled_locales'] = [];
+
+        foreach (array_keys(app(LocalizationSettingsData::class)->available()) as $code) {
+            $data['enabled_locales'][$code] = in_array($code, $enabled, true);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $data['enabled_locales'] = array_keys(array_filter((array) ($data['enabled_locales'] ?? [])));
+
+        return $data;
     }
 }

--- a/app/Http/Controllers/LocalizationController.php
+++ b/app/Http/Controllers/LocalizationController.php
@@ -14,12 +14,10 @@ class LocalizationController extends Controller
      * Switch the session to another language.
      *
      * The trust boundary for the setting: the selector only offers enabled languages, but
-     * nothing stops a client from posting any code, so the check happens here rather than
-     * in the UI.
+     * nothing stops a client from posting any code, so the check happens here.
      *
-     * A signed-in user's choice is written to their record as well as the session, so it
-     * follows them to another browser. Assigned rather than mass-assigned, which keeps
-     * `locale` off `$fillable` until something actually needs to fill it from input.
+     * Assigned rather than mass-assigned, which keeps `locale` off `$fillable` until
+     * something actually needs to fill it from input.
      */
     public function __invoke(Request $request, string $locale): JsonResponse
     {

--- a/app/Http/Controllers/LocalizationController.php
+++ b/app/Http/Controllers/LocalizationController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Settings\LocalizationSettings;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Session;
 
@@ -15,8 +16,12 @@ class LocalizationController extends Controller
      * The trust boundary for the setting: the selector only offers enabled languages, but
      * nothing stops a client from posting any code, so the check happens here rather than
      * in the UI.
+     *
+     * A signed-in user's choice is written to their record as well as the session, so it
+     * follows them to another browser. Assigned rather than mass-assigned, which keeps
+     * `locale` off `$fillable` until something actually needs to fill it from input.
      */
-    public function __invoke(string $locale): JsonResponse
+    public function __invoke(Request $request, string $locale): JsonResponse
     {
         $enabledLocales = array_keys(app(LocalizationSettings::class)->enabled());
 
@@ -26,6 +31,11 @@ class LocalizationController extends Controller
 
         App::setLocale($locale);
         Session::put('locale', $locale);
+
+        if ($user = $request->user()) {
+            $user->locale = $locale;
+            $user->save();
+        }
 
         return new JsonResponse(['locale' => App::getLocale()]);
     }

--- a/app/Http/Controllers/LocalizationController.php
+++ b/app/Http/Controllers/LocalizationController.php
@@ -2,17 +2,26 @@
 
 namespace App\Http\Controllers;
 
+use App\Settings\LocalizationSettings;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Session;
 
 class LocalizationController extends Controller
 {
-    public function __invoke($locale)
+    /**
+     * Switch the session to another language.
+     *
+     * The trust boundary for the setting: the selector only offers enabled languages, but
+     * nothing stops a client from posting any code, so the check happens here rather than
+     * in the UI.
+     */
+    public function __invoke(string $locale): JsonResponse
     {
-        $availableLocales = array_keys(config('app.available_locales', []));
-        if (! in_array($locale, $availableLocales)) {
-            return response(['error' => 'Invalid locale'], 400);
+        $enabledLocales = array_keys(app(LocalizationSettings::class)->enabled());
+
+        if (! in_array($locale, $enabledLocales, true)) {
+            return new JsonResponse(['error' => 'Invalid locale'], 400);
         }
 
         App::setLocale($locale);

--- a/app/Http/Middleware/HandleLocalization.php
+++ b/app/Http/Middleware/HandleLocalization.php
@@ -20,9 +20,9 @@ class HandleLocalization
      * than config. A locale the admin has since turned off is ignored, which is what stops
      * a stale session from pinning a visitor to a retired language.
      *
-     * ponytail: web requests only, which covers the Inertia app and the Filament panel.
-     * Queued jobs and mail still resolve `config('app.locale')`; wire them through the
-     * setting when that becomes a real complaint.
+     * This covers web requests, which is the Inertia app and the Filament panel. Mail and
+     * notifications are handled elsewhere, by `User::preferredLocale()` — Laravel reads
+     * that contract itself, including for queued sends.
      *
      * @param  Closure(Request): (Response)  $next
      */
@@ -33,7 +33,10 @@ class HandleLocalization
 
         Inertia::share('locales', $enabledLocales);
 
-        $locale = Session::get('locale');
+        // A signed-in user's stored choice outranks the session, so logging in somewhere
+        // new brings their language with them rather than inheriting whatever that browser
+        // last looked at. Switching writes both, so the two rarely disagree.
+        $locale = $request->user()->locale ?? Session::get('locale');
 
         App::setLocale(
             is_string($locale) && array_key_exists($locale, $enabledLocales)

--- a/app/Http/Middleware/HandleLocalization.php
+++ b/app/Http/Middleware/HandleLocalization.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Settings\LocalizationSettings;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
@@ -14,21 +15,46 @@ class HandleLocalization
     /**
      * Handle an incoming request.
      *
+     * Which languages exist is a code question; which of them the application offers is an
+     * admin one, so both the shared prop and the session check read the setting rather
+     * than config. A locale the admin has since turned off is ignored, which is what stops
+     * a stale session from pinning a visitor to a retired language.
+     *
+     * ponytail: web requests only, which covers the Inertia app and the Filament panel.
+     * Queued jobs and mail still resolve `config('app.locale')`; wire them through the
+     * setting when that becomes a real complaint.
+     *
      * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {
-        $availableLocales = config('app.available_locales', []);
+        $settings = app(LocalizationSettings::class);
+        $enabledLocales = $settings->enabled();
 
-        Inertia::share('locales', $availableLocales);
+        Inertia::share('locales', $enabledLocales);
 
-        if ($locale = Session::get('locale')) {
+        $locale = Session::get('locale');
 
-            if (in_array($locale, array_keys($availableLocales))) {
-                App::setLocale($locale);
-            }
-        }
+        App::setLocale(
+            is_string($locale) && array_key_exists($locale, $enabledLocales)
+                ? $locale
+                : $this->defaultLocale($settings, $enabledLocales)
+        );
 
         return $next($request);
+    }
+
+    /**
+     * The locale to fall back on, guaranteed to be one the application still offers.
+     *
+     * @param  array<string, string>  $enabledLocales
+     */
+    private function defaultLocale(LocalizationSettings $settings, array $enabledLocales): string
+    {
+        if (array_key_exists($settings->default_locale, $enabledLocales)) {
+            return $settings->default_locale;
+        }
+
+        return (string) array_key_first($enabledLocales);
     }
 }

--- a/app/Http/Middleware/HandleLocalization.php
+++ b/app/Http/Middleware/HandleLocalization.php
@@ -15,14 +15,11 @@ class HandleLocalization
     /**
      * Handle an incoming request.
      *
-     * Which languages exist is a code question; which of them the application offers is an
-     * admin one, so both the shared prop and the session check read the setting rather
-     * than config. A locale the admin has since turned off is ignored, which is what stops
-     * a stale session from pinning a visitor to a retired language.
+     * A locale the admin has since turned off is ignored, which stops a stale session or
+     * user record from pinning a visitor to a retired language.
      *
-     * This covers web requests, which is the Inertia app and the Filament panel. Mail and
-     * notifications are handled elsewhere, by `User::preferredLocale()` — Laravel reads
-     * that contract itself, including for queued sends.
+     * Web requests only. Mail and notifications go through `User::preferredLocale()`,
+     * which Laravel reads itself, including for queued sends.
      *
      * @param  Closure(Request): (Response)  $next
      */
@@ -33,9 +30,6 @@ class HandleLocalization
 
         Inertia::share('locales', $enabledLocales);
 
-        // A signed-in user's stored choice outranks the session, so logging in somewhere
-        // new brings their language with them rather than inheriting whatever that browser
-        // last looked at. Switching writes both, so the two rarely disagree.
         $locale = $request->user()->locale ?? Session::get('locale');
 
         App::setLocale(

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\Role;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -14,7 +15,7 @@ use Spatie\Permission\Traits\HasRoles;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 
-class User extends Authenticatable implements FilamentUser, HasMedia
+class User extends Authenticatable implements FilamentUser, HasLocalePreference, HasMedia
     // , MustVerifyEmail
 {
     use HasFactory;
@@ -96,6 +97,18 @@ class User extends Authenticatable implements FilamentUser, HasMedia
 
         // Final fallback: Default avatar
         return asset('images/default-avatar.jpg');
+    }
+
+    /**
+     * The language to address this user in.
+     *
+     * Laravel reads this contract itself when sending mail and notifications, including
+     * queued ones, which is what makes a user's choice outlive the request they made it
+     * in. Null means they have never chosen, so they follow the application default.
+     */
+    public function preferredLocale(): ?string
+    {
+        return $this->locale;
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\Role;
+use App\Settings\LocalizationSettings;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
 use Illuminate\Contracts\Translation\HasLocalePreference;
@@ -103,12 +104,21 @@ class User extends Authenticatable implements FilamentUser, HasLocalePreference,
      * The language to address this user in.
      *
      * Laravel reads this contract itself when sending mail and notifications, including
-     * queued ones, which is what makes a user's choice outlive the request they made it
-     * in. Null means they have never chosen, so they follow the application default.
+     * queued ones, which is what makes a user's choice outlive the request they made it in.
+     *
+     * Null for a language the admin has since turned off, rather than a substitute one:
+     * `withLocale()` then leaves the ambient locale alone, which the middleware has already
+     * resolved against the enabled set.
      */
     public function preferredLocale(): ?string
     {
-        return $this->locale;
+        if ($this->locale === null) {
+            return null;
+        }
+
+        $enabled = app(LocalizationSettings::class)->enabled();
+
+        return array_key_exists($this->locale, $enabled) ? $this->locale : null;
     }
 
     /**

--- a/app/Notifications/PasswordChangedNotification.php
+++ b/app/Notifications/PasswordChangedNotification.php
@@ -33,16 +33,18 @@ class PasswordChangedNotification extends Notification
      */
     public function toMail(object $notifiable): MailMessage
     {
-        $changedAt = now()->format('F j, Y, g:i a');
+        // isoFormat rather than format: the latter hardcodes English month and meridiem
+        // names no matter what locale the mail is being rendered in.
+        $changedAt = now()->isoFormat('LLL');
 
         return (new MailMessage)
-            ->subject('Password Changed Successfully')
-            ->greeting('Hello '.$notifiable->name.',')
-            ->line('Your password was successfully changed.')
-            ->line('Change time: '.$changedAt)
-            ->line('If you did not make this change, please contact us immediately.')
-            ->action('View Profile', route('settings.profile'))
-            ->line('Thank you for using our application!');
+            ->subject(__('Password Changed Successfully'))
+            ->greeting(__('Hello :name,', ['name' => $notifiable->name]))
+            ->line(__('Your password was successfully changed.'))
+            ->line(__('Change time: :time', ['time' => $changedAt]))
+            ->line(__('If you did not make this change, please contact us immediately.'))
+            ->action(__('View Profile'), route('settings.profile'))
+            ->line(__('Thank you for using our application!'));
     }
 
     /**

--- a/app/Notifications/PasswordChangedNotification.php
+++ b/app/Notifications/PasswordChangedNotification.php
@@ -34,8 +34,6 @@ class PasswordChangedNotification extends Notification
      */
     public function toMail(object $notifiable): MailMessage
     {
-        // isoFormat rather than format: the latter hardcodes English month and meridiem
-        // names no matter what locale the mail is being rendered in.
         $changedAt = now()->isoFormat('LLL');
 
         $mail = (new MailMessage)
@@ -45,9 +43,8 @@ class PasswordChangedNotification extends Notification
             ->line(__('Change time: :time', ['time' => $changedAt]))
             ->line(__('If you did not make this change, please contact us immediately.'));
 
-        // The profile page belongs to the settings module, and this notification does not.
-        // The auth module sends it too, and auth installs without settings — so the button
-        // is a courtesy that disappears rather than a dependency that throws.
+        // The auth module sends this too, and auth installs without settings — so the
+        // button disappears rather than throwing RouteNotFoundException.
         if (Route::has('settings.profile')) {
             $mail->action(__('View Profile'), route('settings.profile'));
         }

--- a/app/Notifications/PasswordChangedNotification.php
+++ b/app/Notifications/PasswordChangedNotification.php
@@ -5,6 +5,7 @@ namespace App\Notifications;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Route;
 
 class PasswordChangedNotification extends Notification
 {
@@ -37,14 +38,21 @@ class PasswordChangedNotification extends Notification
         // names no matter what locale the mail is being rendered in.
         $changedAt = now()->isoFormat('LLL');
 
-        return (new MailMessage)
+        $mail = (new MailMessage)
             ->subject(__('Password Changed Successfully'))
             ->greeting(__('Hello :name,', ['name' => $notifiable->name]))
             ->line(__('Your password was successfully changed.'))
             ->line(__('Change time: :time', ['time' => $changedAt]))
-            ->line(__('If you did not make this change, please contact us immediately.'))
-            ->action(__('View Profile'), route('settings.profile'))
-            ->line(__('Thank you for using our application!'));
+            ->line(__('If you did not make this change, please contact us immediately.'));
+
+        // The profile page belongs to the settings module, and this notification does not.
+        // The auth module sends it too, and auth installs without settings — so the button
+        // is a courtesy that disappears rather than a dependency that throws.
+        if (Route::has('settings.profile')) {
+            $mail->action(__('View Profile'), route('settings.profile'));
+        }
+
+        return $mail->line(__('Thank you for using our application!'));
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,9 @@ use App\Http\Middleware\SecureHeaders;
 use Filament\Forms\Components\Toggle;
 use Filament\Tables\Columns\ToggleColumn;
 use Illuminate\Foundation\Console\AboutCommand;
+use Illuminate\Foundation\Events\LocaleUpdated;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use InterNACHI\Modular\Support\ModuleRegistry;
@@ -31,6 +34,25 @@ class AppServiceProvider extends ServiceProvider
         $this->configureSecureUrls();
         $this->configureFilamentDefaults();
         $this->addCommandAboutInfo();
+        $this->keepDatesInTheApplicationLanguage();
+    }
+
+    /**
+     * Teach Carbon which language the application is currently speaking.
+     *
+     * Laravel does not do this itself: `App::setLocale()` moves the translator and leaves
+     * Carbon behind, so a date rendered with `isoFormat()` keeps its English month names
+     * in a Portuguese email. Listening for the event rather than setting it in middleware
+     * covers the paths a request never touches — queued mail and notifications, which set
+     * the locale themselves from the recipient's `preferredLocale()`.
+     */
+    private function keepDatesInTheApplicationLanguage(): void
+    {
+        Carbon::setLocale($this->app->getLocale());
+
+        Event::listen(LocaleUpdated::class, function (LocaleUpdated $event): void {
+            Carbon::setLocale($event->locale);
+        });
     }
 
     /**

--- a/app/Settings/LocalizationSettings.php
+++ b/app/Settings/LocalizationSettings.php
@@ -23,14 +23,9 @@ use Spatie\LaravelSettings\Settings;
  */
 class LocalizationSettings extends Settings
 {
-    /**
-     * The locales the admin has turned on, as codes.
-     *
-     * @var list<string>
-     */
+    /** @var list<string> */
     public array $enabled_locales;
 
-    /** The locale a visitor gets before they have chosen one. */
     public string $default_locale;
 
     public static function group(): string
@@ -48,7 +43,6 @@ class LocalizationSettings extends Settings
      */
     public function available(): array
     {
-        // ponytail: two globs per request, cache it if it ever shows up in a profile.
         $paths = [
             ...glob(lang_path('*'), GLOB_ONLYDIR) ?: [],
             ...glob(base_path('modules/*/lang/*'), GLOB_ONLYDIR) ?: [],

--- a/app/Settings/LocalizationSettings.php
+++ b/app/Settings/LocalizationSettings.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Settings;
+
+use Illuminate\Support\Str;
+use Locale;
+use Spatie\LaravelSettings\Settings;
+
+/**
+ * Which languages the application offers, and which one it speaks by default.
+ *
+ * Three things decide what appears in the language selector, and each is the only honest
+ * source for its own part of the answer:
+ *
+ * - The filesystem decides which locales *exist*. A locale is real only if translation
+ *   files shipped for it, so {@see available()} looks for them rather than trusting a list.
+ * - `config('app.available_locales')` decides what each one is *called*.
+ * - This object decides which of them the admin *offers*.
+ *
+ * Deliberately separate from {@see GeneralSettings}: the tenancy module clones and
+ * decorates that object per tenant to rebrand it, and adding locales there would make
+ * them per-workspace by accident. Locale is not branding.
+ */
+class LocalizationSettings extends Settings
+{
+    /**
+     * The locales the admin has turned on, as codes.
+     *
+     * @var list<string>
+     */
+    public array $enabled_locales;
+
+    /** The locale a visitor gets before they have chosen one. */
+    public string $default_locale;
+
+    public static function group(): string
+    {
+        return 'localization';
+    }
+
+    /**
+     * Every locale with translation files behind it, mapped to its display name.
+     *
+     * Discovered rather than configured, so dropping `lang/es/` into the application — or
+     * installing a module that ships one — offers Spanish without a code change.
+     *
+     * @return array<string, string>
+     */
+    public function available(): array
+    {
+        // ponytail: two globs per request, cache it if it ever shows up in a profile.
+        $paths = [
+            ...glob(lang_path('*'), GLOB_ONLYDIR) ?: [],
+            ...glob(base_path('modules/*/lang/*'), GLOB_ONLYDIR) ?: [],
+        ];
+
+        $locales = [];
+
+        foreach (array_unique(array_map('basename', $paths)) as $code) {
+            // `lang/vendor/` holds published package translations grouped by package, not
+            // a locale of its own.
+            if ($code === 'vendor') {
+                continue;
+            }
+
+            $locales[$code] = $this->displayName($code);
+        }
+
+        asort($locales);
+
+        return $locales;
+    }
+
+    /**
+     * The subset the admin offers, mapped to display names.
+     *
+     * Never empty: an application with no language at all would render raw translation
+     * keys, so a setting that resolves to nothing falls back to the configured locale.
+     *
+     * @return array<string, string>
+     */
+    public function enabled(): array
+    {
+        $available = $this->available();
+
+        $enabled = array_intersect_key($available, array_flip($this->enabled_locales));
+
+        if ($enabled !== []) {
+            return $enabled;
+        }
+
+        $fallback = (string) config('app.locale', 'en');
+
+        return [$fallback => $available[$fallback] ?? $this->displayName($fallback)];
+    }
+
+    /**
+     * What a locale is called.
+     *
+     * Config first, because a language selector names a language in that language
+     * ("Português", not "Portuguese (Brazil)") and intl does not produce that phrasing.
+     * intl is only a fallback for a locale nobody has named, and `ext-intl` is not a
+     * declared requirement, so its absence has to be survivable.
+     */
+    private function displayName(string $code): string
+    {
+        $configured = config('app.available_locales', [])[$code] ?? null;
+
+        if (is_string($configured)) {
+            return $configured;
+        }
+
+        if (! extension_loaded('intl')) {
+            return $code;
+        }
+
+        return Str::ucfirst(Locale::getDisplayName($code, $code) ?: $code);
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -89,7 +89,16 @@ return [
     | Available locales
     |--------------------------------------------------------------------------
     |
-    | List all locales that your application works with
+    | What each locale is called in the language selector. Names are written as a
+    | speaker of that language would write them ("Português", not "Portuguese"),
+    | which is why they live here rather than being derived.
+    |
+    | This list does not decide which languages the application offers. A locale
+    | is discovered from its "lang/" directory, in the application or in any
+    | installed module, whether or not it is named here; a discovered locale with
+    | no entry falls back to its own code. Which of them visitors can switch
+    | between, and which one is the default, are set in the admin panel under
+    | Settings, and stored via App\Settings\LocalizationSettings.
     |
     */
     'available_locales' => [

--- a/database/migrations/0001_01_01_000008_add_locale_to_users_table.php
+++ b/database/migrations/0001_01_01_000008_add_locale_to_users_table.php
@@ -13,8 +13,6 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table) {
-            // Null until the user picks one, which is what lets them keep inheriting the
-            // application default rather than being frozen to whatever it was at signup.
             $table->string('locale')->nullable()->after('avatar');
         });
     }

--- a/database/migrations/0001_01_01_000008_add_locale_to_users_table.php
+++ b/database/migrations/0001_01_01_000008_add_locale_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Added separately rather than inlined into the users table, which is already live
+     * wherever this application is deployed.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            // Null until the user picks one, which is what lets them keep inheriting the
+            // application default rather than being frozen to whatever it was at signup.
+            $table->string('locale')->nullable()->after('avatar');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('locale');
+        });
+    }
+};

--- a/database/settings/0001_01_01_000012_create_localization_settings.php
+++ b/database/settings/0001_01_01_000012_create_localization_settings.php
@@ -6,8 +6,7 @@ return new class extends SettingsMigration
 {
     public function up(): void
     {
-        // Seeded from the config that used to be the whole answer, so an existing
-        // installation keeps offering exactly the languages it offered before.
+        // Seeded from config so an existing installation keeps the languages it had.
         if (! $this->migrator->exists('localization.enabled_locales')) {
             $this->migrator->add(
                 'localization.enabled_locales',

--- a/database/settings/0001_01_01_000012_create_localization_settings.php
+++ b/database/settings/0001_01_01_000012_create_localization_settings.php
@@ -1,0 +1,22 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        // Seeded from the config that used to be the whole answer, so an existing
+        // installation keeps offering exactly the languages it offered before.
+        if (! $this->migrator->exists('localization.enabled_locales')) {
+            $this->migrator->add(
+                'localization.enabled_locales',
+                array_keys(config('app.available_locales', ['en' => 'English'])),
+            );
+        }
+
+        if (! $this->migrator->exists('localization.default_locale')) {
+            $this->migrator->add('localization.default_locale', config('app.locale', 'en'));
+        }
+    }
+};

--- a/resources/js/react/components/LanguageSelector.tsx
+++ b/resources/js/react/components/LanguageSelector.tsx
@@ -39,6 +39,11 @@ export default function LanguageSelector({
         Icon: iconMap[code] ?? null,
     }));
 
+    // Nothing to choose between is nothing to show.
+    if (languages.length <= 1) {
+        return null;
+    }
+
     const currentLanguage =
         languages.find((l) => l.code === language) ?? languages[0];
     const CurrentIcon = currentLanguage?.Icon ?? null;

--- a/resources/js/react/components/LanguageSelector.tsx
+++ b/resources/js/react/components/LanguageSelector.tsx
@@ -39,7 +39,6 @@ export default function LanguageSelector({
         Icon: iconMap[code] ?? null,
     }));
 
-    // Nothing to choose between is nothing to show.
     if (languages.length <= 1) {
         return null;
     }

--- a/resources/js/vue/components/LanguageSelector.vue
+++ b/resources/js/vue/components/LanguageSelector.vue
@@ -65,11 +65,8 @@ const currentLanguage = computed(() => {
 </script>
 
 <template>
-    <!--
-        Nothing to choose between is nothing to show. Wrapping rather than folding the
-        condition into the v-if below, which would leave the v-else rendering the submenu
-        in the single-language case.
-    -->
+    <!-- Wrapped rather than folded into the v-if below, whose v-else would otherwise
+         render the submenu in the single-language case. -->
     <template v-if="languages.length > 1">
         <!-- Standalone Mode (Landing Page) -->
         <DropdownMenu v-if="mode === 'standalone'" :modal="false">

--- a/resources/js/vue/components/LanguageSelector.vue
+++ b/resources/js/vue/components/LanguageSelector.vue
@@ -65,54 +65,68 @@ const currentLanguage = computed(() => {
 </script>
 
 <template>
-    <!-- Standalone Mode (Landing Page) -->
-    <DropdownMenu v-if="mode === 'standalone'" :modal="false">
-        <DropdownMenuTrigger as-child>
-            <button
-                :class="props.triggerClass"
-                :aria-label="$t('Language Selector')"
-            >
-                <slot name="trigger" :current-language="currentLanguage">
-                    <component :is="currentLanguage.icon" class="size-4.5" />
-                </slot>
-            </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" class="min-w-40">
-            <DropdownMenuItem
-                v-for="lang in languages"
-                :key="lang.code"
-                @click="switchLanguage(lang.code)"
-                :class="{
-                    'bg-accent text-accent-foreground': language === lang.code,
-                }"
-            >
-                <component :is="lang.icon" class="size-4" />
-                {{ lang.name }}
-            </DropdownMenuItem>
-        </DropdownMenuContent>
-    </DropdownMenu>
+    <!--
+        Nothing to choose between is nothing to show. Wrapping rather than folding the
+        condition into the v-if below, which would leave the v-else rendering the submenu
+        in the single-language case.
+    -->
+    <template v-if="languages.length > 1">
+        <!-- Standalone Mode (Landing Page) -->
+        <DropdownMenu v-if="mode === 'standalone'" :modal="false">
+            <DropdownMenuTrigger as-child>
+                <button
+                    :class="props.triggerClass"
+                    :aria-label="$t('Language Selector')"
+                >
+                    <slot name="trigger" :current-language="currentLanguage">
+                        <component
+                            :is="currentLanguage.icon"
+                            class="size-4.5"
+                        />
+                    </slot>
+                </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" class="min-w-40">
+                <DropdownMenuItem
+                    v-for="lang in languages"
+                    :key="lang.code"
+                    @click="switchLanguage(lang.code)"
+                    :class="{
+                        'bg-accent text-accent-foreground':
+                            language === lang.code,
+                    }"
+                >
+                    <component :is="lang.icon" class="size-4" />
+                    {{ lang.name }}
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
 
-    <!-- Submenu Mode (NavUser) -->
-    <DropdownMenuSub v-else>
-        <DropdownMenuSubTrigger
-            data-testid="language-selector-trigger"
-            class="[&>svg]:text-muted-foreground [&>svg]:mr-2"
-        >
-            <slot name="submenu-trigger" :current-language="currentLanguage">
-                <Globe class="size-3.5" />
-                {{ $t('Language') }}
-            </slot>
-        </DropdownMenuSubTrigger>
-        <DropdownMenuSubContent>
-            <DropdownMenuItem
-                v-for="lang in languages"
-                :key="lang.code"
-                @click="switchLanguage(lang.code)"
-                :class="{ 'bg-accent': language === lang.code }"
+        <!-- Submenu Mode (NavUser) -->
+        <DropdownMenuSub v-else>
+            <DropdownMenuSubTrigger
+                data-testid="language-selector-trigger"
+                class="[&>svg]:text-muted-foreground [&>svg]:mr-2"
             >
-                <component :is="lang.icon" class="h-4 w-4" />
-                {{ lang.name }}
-            </DropdownMenuItem>
-        </DropdownMenuSubContent>
-    </DropdownMenuSub>
+                <slot
+                    name="submenu-trigger"
+                    :current-language="currentLanguage"
+                >
+                    <Globe class="size-3.5" />
+                    {{ $t('Language') }}
+                </slot>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+                <DropdownMenuItem
+                    v-for="lang in languages"
+                    :key="lang.code"
+                    @click="switchLanguage(lang.code)"
+                    :class="{ 'bg-accent': language === lang.code }"
+                >
+                    <component :is="lang.icon" class="h-4 w-4" />
+                    {{ lang.name }}
+                </DropdownMenuItem>
+            </DropdownMenuSubContent>
+        </DropdownMenuSub>
+    </template>
 </template>

--- a/tests/Feature/LocalizationSettingsTest.php
+++ b/tests/Feature/LocalizationSettingsTest.php
@@ -157,11 +157,32 @@ class LocalizationSettingsTest extends TestCase
 
     public function test_a_user_language_drives_notifications(): void
     {
+        $this->setEnabledLocales(['en', 'pt_BR'], 'en');
+
         $user = User::factory()->create(['locale' => 'pt_BR']);
 
         // The contract Laravel reads when sending, which is what carries the choice
         // beyond the request it was made in.
         $this->assertSame('pt_BR', $user->preferredLocale());
+    }
+
+    public function test_a_user_who_never_chose_expresses_no_preference(): void
+    {
+        $user = User::factory()->create(['locale' => null]);
+
+        // Null leaves withLocale() alone, so a notification sent mid-request stays in the
+        // language the visitor is actually reading.
+        $this->assertNull($user->preferredLocale());
+    }
+
+    public function test_a_user_language_that_is_no_longer_enabled_expresses_no_preference(): void
+    {
+        $user = User::factory()->create(['locale' => 'pt_BR']);
+
+        $this->setEnabledLocales(['en'], 'en');
+
+        // Otherwise the browser would say English and the email would still say Portuguese.
+        $this->assertNull($user->fresh()->preferredLocale());
     }
 
     public function test_enabled_never_resolves_to_no_language(): void

--- a/tests/Feature/LocalizationSettingsTest.php
+++ b/tests/Feature/LocalizationSettingsTest.php
@@ -107,6 +107,63 @@ class LocalizationSettingsTest extends TestCase
         $this->assertNull(session('locale'));
     }
 
+    public function test_switching_stores_the_language_on_the_signed_in_user(): void
+    {
+        $this->setEnabledLocales(['en', 'pt_BR'], 'en');
+
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->post('/locale/pt_BR')->assertOk();
+
+        $this->assertSame('pt_BR', $user->fresh()->locale);
+    }
+
+    public function test_a_stored_user_language_survives_a_new_session(): void
+    {
+        $this->setEnabledLocales(['en', 'pt_BR'], 'en');
+
+        $user = User::factory()->create(['locale' => 'pt_BR']);
+
+        // No session locale at all: a different browser, or a session that has expired.
+        $this->actingAs($user)->get('/localization-probe')->assertOk();
+
+        $this->assertSame('pt_BR', app()->getLocale());
+    }
+
+    public function test_a_stored_user_language_outranks_the_session(): void
+    {
+        $this->setEnabledLocales(['en', 'pt_BR'], 'en');
+
+        $user = User::factory()->create(['locale' => 'pt_BR']);
+
+        $this->actingAs($user)
+            ->withSession(['locale' => 'en'])
+            ->get('/localization-probe')
+            ->assertOk();
+
+        $this->assertSame('pt_BR', app()->getLocale());
+    }
+
+    public function test_a_stored_user_language_that_is_no_longer_enabled_falls_back(): void
+    {
+        $user = User::factory()->create(['locale' => 'pt_BR']);
+
+        $this->setEnabledLocales(['en'], 'en');
+
+        $this->actingAs($user)->get('/localization-probe')->assertOk();
+
+        $this->assertSame('en', app()->getLocale());
+    }
+
+    public function test_a_user_language_drives_notifications(): void
+    {
+        $user = User::factory()->create(['locale' => 'pt_BR']);
+
+        // The contract Laravel reads when sending, which is what carries the choice
+        // beyond the request it was made in.
+        $this->assertSame('pt_BR', $user->preferredLocale());
+    }
+
     public function test_enabled_never_resolves_to_no_language(): void
     {
         $this->setEnabledLocales([], 'en');

--- a/tests/Feature/LocalizationSettingsTest.php
+++ b/tests/Feature/LocalizationSettingsTest.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\Role;
+use App\Filament\Admin\Pages\LocalizationSettings as LocalizationSettingsPage;
+use App\Models\User;
+use App\Settings\LocalizationSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+use Inertia\Testing\AssertableInertia;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class LocalizationSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware('web')->get('/localization-probe', fn () => Inertia::render('Index'));
+    }
+
+    public function test_fresh_install_offers_the_locales_that_ship(): void
+    {
+        $settings = app(LocalizationSettings::class);
+
+        $this->assertSame(['en', 'pt_BR'], $settings->enabled_locales);
+        $this->assertSame('en', $settings->default_locale);
+    }
+
+    public function test_settings_migration_preserves_existing_values(): void
+    {
+        $this->setEnabledLocales(['en'], 'en');
+
+        $migration = require database_path('settings/0001_01_01_000012_create_localization_settings.php');
+        $migration->up();
+
+        app()->forgetInstance(LocalizationSettings::class);
+        $settings = app(LocalizationSettings::class);
+
+        $this->assertSame(['en'], $settings->enabled_locales);
+    }
+
+    public function test_available_locales_are_discovered_from_lang_directories(): void
+    {
+        $available = app(LocalizationSettings::class)->available();
+
+        // Both ship in core; pt_BR also ships inside several modules, which must not
+        // produce a duplicate.
+        $this->assertSame(['en', 'pt_BR'], array_keys($available));
+
+        // Named from config, so the selector shows the endonym rather than an intl string
+        // like "Portuguese (Brazil)".
+        $this->assertSame('Português', $available['pt_BR']);
+    }
+
+    public function test_disabling_a_locale_removes_it_from_the_shared_prop(): void
+    {
+        $this->setEnabledLocales(['en'], 'en');
+
+        $this->get('/localization-probe')->assertInertia(
+            fn (AssertableInertia $page) => $page->where('locales', ['en' => 'English'])
+        );
+    }
+
+    public function test_default_locale_applies_when_the_visitor_has_not_chosen(): void
+    {
+        $this->setEnabledLocales(['en', 'pt_BR'], 'pt_BR');
+
+        $this->get('/localization-probe')->assertOk();
+
+        $this->assertSame('pt_BR', app()->getLocale());
+    }
+
+    public function test_a_session_locale_that_is_no_longer_enabled_is_ignored(): void
+    {
+        $this->setEnabledLocales(['en'], 'en');
+
+        $this->withSession(['locale' => 'pt_BR'])->get('/localization-probe')->assertOk();
+
+        $this->assertSame('en', app()->getLocale());
+    }
+
+    public function test_switching_to_an_enabled_locale_is_accepted(): void
+    {
+        $this->setEnabledLocales(['en', 'pt_BR'], 'en');
+
+        $this->post('/locale/pt_BR')
+            ->assertOk()
+            ->assertJson(['locale' => 'pt_BR']);
+
+        $this->assertSame('pt_BR', session('locale'));
+    }
+
+    public function test_switching_to_a_disabled_locale_is_rejected(): void
+    {
+        $this->setEnabledLocales(['en'], 'en');
+
+        $this->post('/locale/pt_BR')
+            ->assertStatus(400)
+            ->assertJson(['error' => 'Invalid locale']);
+
+        $this->assertNull(session('locale'));
+    }
+
+    public function test_enabled_never_resolves_to_no_language(): void
+    {
+        $this->setEnabledLocales([], 'en');
+
+        // An empty setting would otherwise leave the application rendering raw keys.
+        $this->assertSame(['en' => 'English'], app(LocalizationSettings::class)->enabled());
+    }
+
+    public function test_a_default_locale_that_is_no_longer_enabled_falls_back(): void
+    {
+        $this->setEnabledLocales(['pt_BR'], 'en');
+
+        $this->get('/localization-probe')->assertOk();
+
+        $this->assertSame('pt_BR', app()->getLocale());
+    }
+
+    public function test_administrator_can_save_localization_settings(): void
+    {
+        $this->actingAsAdmin();
+
+        Livewire::test(LocalizationSettingsPage::class)
+            ->assertSchemaStateSet([
+                'enabled_locales' => ['en', 'pt_BR'],
+                'default_locale' => 'en',
+            ])
+            ->fillForm([
+                'enabled_locales' => ['pt_BR'],
+                'default_locale' => 'pt_BR',
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors()
+            ->assertNotified();
+
+        app()->forgetInstance(LocalizationSettings::class);
+        $settings = app(LocalizationSettings::class);
+
+        $this->assertSame(['pt_BR'], $settings->enabled_locales);
+        $this->assertSame('pt_BR', $settings->default_locale);
+    }
+
+    public function test_at_least_one_language_must_stay_enabled(): void
+    {
+        $this->actingAsAdmin();
+
+        Livewire::test(LocalizationSettingsPage::class)
+            ->fillForm([
+                'enabled_locales' => [],
+                'default_locale' => 'en',
+            ])
+            ->call('save')
+            ->assertHasFormErrors(['enabled_locales']);
+
+        app()->forgetInstance(LocalizationSettings::class);
+
+        $this->assertSame(['en', 'pt_BR'], app(LocalizationSettings::class)->enabled_locales);
+    }
+
+    /**
+     * @param  list<string>  $locales
+     */
+    private function setEnabledLocales(array $locales, string $default): void
+    {
+        $settings = app(LocalizationSettings::class);
+        $settings->enabled_locales = $locales;
+        $settings->default_locale = $default;
+        $settings->save();
+
+        app()->forgetInstance(LocalizationSettings::class);
+    }
+
+    private function actingAsAdmin(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole(Role::ADMIN);
+
+        $this->actingAs($admin);
+    }
+}

--- a/tests/Feature/LocalizationSettingsTest.php
+++ b/tests/Feature/LocalizationSettingsTest.php
@@ -185,15 +185,13 @@ class LocalizationSettingsTest extends TestCase
     {
         $this->actingAsAdmin();
 
-        // One toggle per language, so the form speaks booleans while the setting stores
-        // a list of codes.
         Livewire::test(LocalizationSettingsPage::class)
             ->assertSchemaStateSet([
-                'enabled_locales' => ['en' => true, 'pt_BR' => true],
+                'enabled_locales' => ['en', 'pt_BR'],
                 'default_locale' => 'en',
             ])
             ->fillForm([
-                'enabled_locales' => ['en' => false, 'pt_BR' => true],
+                'enabled_locales' => ['pt_BR'],
                 'default_locale' => 'pt_BR',
             ])
             ->call('save')
@@ -213,11 +211,11 @@ class LocalizationSettingsTest extends TestCase
 
         Livewire::test(LocalizationSettingsPage::class)
             ->fillForm([
-                'enabled_locales' => ['en' => false, 'pt_BR' => false],
+                'enabled_locales' => [],
                 'default_locale' => 'en',
             ])
             ->call('save')
-            ->assertHasFormErrors(['default_locale']);
+            ->assertHasFormErrors(['enabled_locales']);
 
         app()->forgetInstance(LocalizationSettings::class);
 

--- a/tests/Feature/LocalizationSettingsTest.php
+++ b/tests/Feature/LocalizationSettingsTest.php
@@ -128,13 +128,15 @@ class LocalizationSettingsTest extends TestCase
     {
         $this->actingAsAdmin();
 
+        // One toggle per language, so the form speaks booleans while the setting stores
+        // a list of codes.
         Livewire::test(LocalizationSettingsPage::class)
             ->assertSchemaStateSet([
-                'enabled_locales' => ['en', 'pt_BR'],
+                'enabled_locales' => ['en' => true, 'pt_BR' => true],
                 'default_locale' => 'en',
             ])
             ->fillForm([
-                'enabled_locales' => ['pt_BR'],
+                'enabled_locales' => ['en' => false, 'pt_BR' => true],
                 'default_locale' => 'pt_BR',
             ])
             ->call('save')
@@ -154,11 +156,11 @@ class LocalizationSettingsTest extends TestCase
 
         Livewire::test(LocalizationSettingsPage::class)
             ->fillForm([
-                'enabled_locales' => [],
+                'enabled_locales' => ['en' => false, 'pt_BR' => false],
                 'default_locale' => 'en',
             ])
             ->call('save')
-            ->assertHasFormErrors(['enabled_locales']);
+            ->assertHasFormErrors(['default_locale']);
 
         app()->forgetInstance(LocalizationSettings::class);
 

--- a/tests/Feature/NotificationTranslatabilityTest.php
+++ b/tests/Feature/NotificationTranslatabilityTest.php
@@ -8,16 +8,19 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Lang;
-use Modules\Auth\Notifications\WelcomeNotification;
+use Illuminate\Support\Facades\Route;
 use Tests\TestCase;
 
 /**
  * Every line a user reads has to reach them through the translator.
  *
  * A hardcoded string is invisible until somebody installs a language and finds half the
- * email still in English, so these tests render each notification under a fake locale
- * whose every string is replaced. Anything that comes back in English was concatenated
- * rather than translated.
+ * email still in English, so these tests render the notification under a fake locale whose
+ * every string is replaced. Anything that comes back in English was concatenated rather
+ * than translated.
+ *
+ * Only core notifications belong here. A module's own are covered inside that module, so
+ * this suite keeps passing on an installation that does not have it.
  */
 class NotificationTranslatabilityTest extends TestCase
 {
@@ -42,25 +45,9 @@ class NotificationTranslatabilityTest extends TestCase
         $mail = (new PasswordChangedNotification)->toMail($user);
 
         $this->assertSame('ALTERADA', $mail->subject);
-        $this->assertSame('PERFIL', $mail->actionText);
         $this->assertContains('TROCADA', $mail->introLines);
         $this->assertContains('CONTATE', $mail->introLines);
         $this->assertContains('OBRIGADO', $mail->outroLines);
-    }
-
-    public function test_welcome_notification_translates_every_line(): void
-    {
-        $user = User::factory()->create(['name' => 'Ana']);
-
-        App::setLocale('xx');
-
-        $mail = (new WelcomeNotification)->toMail($user);
-
-        $this->assertStringStartsWith('BEMVINDO', $mail->subject);
-        $this->assertSame('PAINEL', $mail->actionText);
-        $this->assertContains('CRIADA', $mail->introLines);
-        $this->assertContains('EXPLORE', $mail->introLines);
-        $this->assertContains('GRATO', $mail->outroLines);
     }
 
     public function test_the_recipient_name_is_a_placeholder_not_a_concatenation(): void
@@ -71,7 +58,25 @@ class NotificationTranslatabilityTest extends TestCase
 
         // Building the greeting with "." would leave "Hello" permanently English.
         $this->assertSame('OLA Ana,', (new PasswordChangedNotification)->toMail($user)->greeting);
-        $this->assertSame('OLA Ana,', (new WelcomeNotification)->toMail($user)->greeting);
+    }
+
+    /**
+     * The profile button points into the settings module, which core installs without.
+     */
+    public function test_the_profile_button_appears_only_where_the_route_exists(): void
+    {
+        $user = User::factory()->create();
+
+        App::setLocale('xx');
+
+        if (Route::has('settings.profile')) {
+            $this->assertSame('PERFIL', (new PasswordChangedNotification)->toMail($user)->actionText);
+
+            return;
+        }
+
+        // Without the settings module the mail still sends, minus the button.
+        $this->assertNull((new PasswordChangedNotification)->toMail($user)->actionText);
     }
 
     /**

--- a/tests/Feature/NotificationTranslatabilityTest.php
+++ b/tests/Feature/NotificationTranslatabilityTest.php
@@ -44,10 +44,15 @@ class NotificationTranslatabilityTest extends TestCase
 
         $mail = (new PasswordChangedNotification)->toMail($user);
 
+        // Merged, because MailMessage sorts lines into intro or outro depending on whether
+        // an action came before them — and the action here is absent without the settings
+        // module. Which bucket a line lands in is not what this test is about.
+        $lines = [...$mail->introLines, ...$mail->outroLines];
+
         $this->assertSame('ALTERADA', $mail->subject);
-        $this->assertContains('TROCADA', $mail->introLines);
-        $this->assertContains('CONTATE', $mail->introLines);
-        $this->assertContains('OBRIGADO', $mail->outroLines);
+        $this->assertContains('TROCADA', $lines);
+        $this->assertContains('CONTATE', $lines);
+        $this->assertContains('OBRIGADO', $lines);
     }
 
     public function test_the_recipient_name_is_a_placeholder_not_a_concatenation(): void

--- a/tests/Feature/NotificationTranslatabilityTest.php
+++ b/tests/Feature/NotificationTranslatabilityTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Notifications\PasswordChangedNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Lang;
+use Modules\Auth\Notifications\WelcomeNotification;
+use Tests\TestCase;
+
+/**
+ * Every line a user reads has to reach them through the translator.
+ *
+ * A hardcoded string is invisible until somebody installs a language and finds half the
+ * email still in English, so these tests render each notification under a fake locale
+ * whose every string is replaced. Anything that comes back in English was concatenated
+ * rather than translated.
+ */
+class NotificationTranslatabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The real JSON loading path, rather than Lang::addLines() — that helper routes
+        // keys through Arr::set(), which splits on dots and mangles any string ending in
+        // a full stop.
+        Lang::addJsonPath(base_path('tests/fixtures/lang'));
+    }
+
+    public function test_password_changed_notification_translates_every_line(): void
+    {
+        $user = User::factory()->create(['name' => 'Ana']);
+
+        App::setLocale('xx');
+
+        $mail = (new PasswordChangedNotification)->toMail($user);
+
+        $this->assertSame('ALTERADA', $mail->subject);
+        $this->assertSame('PERFIL', $mail->actionText);
+        $this->assertContains('TROCADA', $mail->introLines);
+        $this->assertContains('CONTATE', $mail->introLines);
+        $this->assertContains('OBRIGADO', $mail->outroLines);
+    }
+
+    public function test_welcome_notification_translates_every_line(): void
+    {
+        $user = User::factory()->create(['name' => 'Ana']);
+
+        App::setLocale('xx');
+
+        $mail = (new WelcomeNotification)->toMail($user);
+
+        $this->assertStringStartsWith('BEMVINDO', $mail->subject);
+        $this->assertSame('PAINEL', $mail->actionText);
+        $this->assertContains('CRIADA', $mail->introLines);
+        $this->assertContains('EXPLORE', $mail->introLines);
+        $this->assertContains('GRATO', $mail->outroLines);
+    }
+
+    public function test_the_recipient_name_is_a_placeholder_not_a_concatenation(): void
+    {
+        $user = User::factory()->create(['name' => 'Ana']);
+
+        App::setLocale('xx');
+
+        // Building the greeting with "." would leave "Hello" permanently English.
+        $this->assertSame('OLA Ana,', (new PasswordChangedNotification)->toMail($user)->greeting);
+        $this->assertSame('OLA Ana,', (new WelcomeNotification)->toMail($user)->greeting);
+    }
+
+    /**
+     * `format()` hardcodes English month and meridiem names. `isoFormat()` only helps if
+     * Carbon has been told which language the application is speaking.
+     */
+    public function test_dates_in_mail_follow_the_application_language(): void
+    {
+        $user = User::factory()->create();
+
+        Carbon::setTestNow('2026-08-24 15:19:00');
+        App::setLocale('pt_BR');
+
+        $mail = (new PasswordChangedNotification)->toMail($user);
+        $line = collect($mail->introLines)->first(fn (string $line): bool => str_contains($line, '2026'));
+
+        $this->assertNotNull($line, 'Expected a line carrying the change time.');
+        $this->assertStringContainsString('agosto', $line);
+    }
+
+    public function test_carbon_tracks_the_application_locale_in_both_directions(): void
+    {
+        App::setLocale('pt_BR');
+        $this->assertSame('pt_BR', Carbon::getLocale());
+
+        App::setLocale('en');
+        $this->assertSame('en', Carbon::getLocale());
+    }
+}

--- a/tests/fixtures/lang/xx.json
+++ b/tests/fixtures/lang/xx.json
@@ -1,0 +1,14 @@
+{
+    "Password Changed Successfully": "ALTERADA",
+    "Your password was successfully changed.": "TROCADA",
+    "If you did not make this change, please contact us immediately.": "CONTATE",
+    "View Profile": "PERFIL",
+    "Thank you for using our application!": "OBRIGADO",
+    "Hello :name,": "OLA :name,",
+    "Change time: :time": "HORA: :time",
+    "Welcome to :app!": "BEMVINDO :app",
+    "Welcome! Your account has been created successfully.": "CRIADA",
+    "You can now explore all the features available to you.": "EXPLORE",
+    "Go to Dashboard": "PAINEL",
+    "Thank you for joining us!": "GRATO"
+}


### PR DESCRIPTION
This pull request introduces a comprehensive overhaul of the application's localization system, transitioning from a config-based approach to a dynamic, admin-configurable, and database-backed language management system. It adds a new `LocalizationSettings` settings class, enables administrators to configure available and default languages via the admin panel, ensures user language preferences persist across sessions and devices, and updates both backend and frontend logic to reflect these changes. The changes also ensure that language selectors are only shown when multiple languages are available, and that user-specific locale preferences are respected throughout the application, including queued notifications.

**Localization system redesign and settings management:**

* Introduced `LocalizationSettings` (`app/Settings/LocalizationSettings.php`) to manage which languages are available and which one is the default, discovering locales from the filesystem and mapping them to display names from config or via intl. This enables dynamic language management without code changes.
* Added a Filament admin page (`app/Filament/Admin/Pages/LocalizationSettings.php`) to allow administrators to enable/disable languages and set the default language through the UI, with logic to ensure at least one language is always enabled.
* Added a settings migration (`database/settings/0001_01_01_000012_create_localization_settings.php`) to seed enabled and default locales from existing config, ensuring a smooth transition for existing installations.

**User locale preference and persistence:**

* Added a nullable `locale` column to the `users` table via migration, allowing users to have a persistent language preference that can override session or browser settings.
* Updated the `User` model to implement `HasLocalePreference` and provide a `preferredLocale()` method, ensuring Laravel uses the user's chosen language for mail and notifications. [[1]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR8) [[2]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbL17-R18) [[3]](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR102-R113)

**Backend language selection and enforcement:**

* Refactored `LocalizationController` and `HandleLocalization` middleware to use enabled locales from settings, enforce that only enabled languages can be selected, and ensure that user preferences take precedence over session or browser defaults. [[1]](diffhunk://#diff-5815f1cb143eee5c7b2916dbfc2e5776b003841513da5e2926558c0ccfa0bd0bR5-R39) [[2]](diffhunk://#diff-f5ebe948e7bb228282b5a377ec7afa26d5d57e9cf72503f46310502ef7effd69R5) [[3]](diffhunk://#diff-f5ebe948e7bb228282b5a377ec7afa26d5d57e9cf72503f46310502ef7effd69R18-R61)

**Frontend language selector improvements:**

* Updated both React and Vue language selectors to only display when more than one language is available, preventing unnecessary UI clutter when the app is single-language. [[1]](diffhunk://#diff-6110ee9ba3c2acd31010e9b28c9883b52cd5e31e69b8f4cfa5002dc0d08ffed3R42-R46) [[2]](diffhunk://#diff-339210a2fb71c6b07806c06fc0b3dee6e1e22f440422e49df5a473eafce0a4abR68-R73) [[3]](diffhunk://#diff-339210a2fb71c6b07806c06fc0b3dee6e1e22f440422e49df5a473eafce0a4abL76-R85) [[4]](diffhunk://#diff-339210a2fb71c6b07806c06fc0b3dee6e1e22f440422e49df5a473eafce0a4abL86-R96) [[5]](diffhunk://#diff-339210a2fb71c6b07806c06fc0b3dee6e1e22f440422e49df5a473eafce0a4abL101-R114) [[6]](diffhunk://#diff-339210a2fb71c6b07806c06fc0b3dee6e1e22f440422e49df5a473eafce0a4abR132)

**Configuration and documentation updates:**

* Clarified in `config/app.php` that `available_locales` is only for display names, and that actual available and enabled languages are now managed via settings and discovered from the filesystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added administrator controls for selecting enabled languages and a default language.
  - Added automatic discovery of available translations.
  - Users can save a preferred language for future sessions.
  - Language selection now follows user, session, and configured defaults.
  - Password-change notifications support translated content and localized dates.

- **Bug Fixes**
  - Language selectors are hidden when fewer than two languages are available.
  - Invalid language choices now fall back safely to an enabled language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->