### PR TITLE
Refactor installation process and update command references

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,19 +37,6 @@ includes:
     # ── END MODULES ──────────────────────────────────────────────────
 
 tasks:
-    # ── Installation ──────────────────────────────────────────────
-
-    install:docker:
-        desc: Fresh install — Docker + Node required
-        cmd: bash bin/setup-env {{.CLI_ARGS}}
-
-    install:
-        desc: Fresh install (PHP, Composer, Node required)
-        cmds:
-            - composer install
-            - '{{.APP}} php artisan saucebase:install --all-modules'
-            - npm install
-
     # ── Development ───────────────────────────────────────────────
 
     dev:

--- a/app/Console/Commands/SauceBase/RecipeToModuleCommand.php
+++ b/app/Console/Commands/SauceBase/RecipeToModuleCommand.php
@@ -67,7 +67,7 @@ class RecipeToModuleCommand extends Command
         $framework = $frontendConfig->getFramework();
 
         if ($framework === null) {
-            error('No frontend framework selected. Run `php artisan saucebase:stack vue` or `php artisan saucebase:stack react` first.');
+            error('No frontend framework selected. Run `saucebase stack vue` or `saucebase stack react` first.');
 
             return true;
         }

--- a/resources/views/setup.blade.php
+++ b/resources/views/setup.blade.php
@@ -256,8 +256,8 @@
 
     <script>
         const commands = {
-            vue: 'php artisan saucebase:install vue',
-            react: 'php artisan saucebase:install react',
+            vue: 'saucebase stack vue',
+            react: 'saucebase stack react',
         };
         let currentCommand = '';
         let typingTimer = null;

--- a/tests/Feature/IndexControllerTest.php
+++ b/tests/Feature/IndexControllerTest.php
@@ -59,7 +59,8 @@ class IndexControllerTest extends TestCase
         $this->bindFramework(null);
 
         $this->get('/')
-            ->assertSeeText('saucebase:install vue')
-            ->assertSeeText('saucebase:install react');
+            ->assertSeeText('saucebase stack vue')
+            ->assertSeeText('saucebase stack react')
+            ->assertDontSeeText('php artisan saucebase:install');
     }
 }

--- a/tests/Unit/Console/Commands/RecipeToModuleCommandTest.php
+++ b/tests/Unit/Console/Commands/RecipeToModuleCommandTest.php
@@ -221,7 +221,7 @@ class RecipeToModuleCommandTest extends TestCase
         $this->writeFrontendJson(['framework' => null]);
 
         $this->artisan('saucebase:recipe', ['module' => 'TestExit'])
-            ->expectsOutputToContain('No frontend framework selected');
+            ->expectsPromptsError('No frontend framework selected. Run `saucebase stack vue` or `saucebase stack react` first.');
 
         $this->assertDirectoryDoesNotExist($this->tmpDir.'/modules/test-exit');
     }


### PR DESCRIPTION
This pull request updates the installation and setup commands throughout the codebase to use the new `saucebase stack` CLI commands instead of the older `php artisan saucebase:install` format. It also removes some obsolete install tasks from the `Taskfile.yml`. These changes improve consistency and clarity for users interacting with the setup process.

**Command update and consistency improvements:**

* Updated error messages and setup instructions to reference `saucebase stack vue` and `saucebase stack react` instead of the old `php artisan saucebase:install` commands in `RecipeToModuleCommand.php` and `setup.blade.php` [[1]](diffhunk://#diff-5e6dd6323111b5c2bdd4e96893172e4209088ae2b227f8c3693a69b58f2c9c7aL70-R70) [[2]](diffhunk://#diff-485c9af2eb24cf3c9f613d5f6ba95d9acb7079eb5b2955cf1c0308ab88267c87L259-R260).
* Adjusted feature and unit tests to expect the new command format, ensuring test coverage aligns with the updated CLI usage in `IndexControllerTest.php` and `RecipeToModuleCommandTest.php` [[1]](diffhunk://#diff-aea0e3402d01a1dbb07e1a50fa2a5ba489fa3c6904cdd30c832c0431615bdfe3L62-R64) [[2]](diffhunk://#diff-3dfd709ba74056ea3de1163a181bf8d04dc68015bdfa1927d00e3ccf0dd300faL224-R224).

**Taskfile cleanup:**

* Removed obsolete installation tasks (`install:docker` and `install`) from `Taskfile.yml` that referenced the old install commands, reflecting the move to the new CLI workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated setup instructions to use the streamlined `saucebase stack vue` and `saucebase stack react` commands.
  * Improved guidance when no frontend framework is selected.

* **Chores**
  * Removed legacy fresh-install task workflows.

* **Tests**
  * Updated setup and error-message checks to reflect the new command syntax and ensure legacy commands are no longer shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->