### PR TITLE
refactor: remove settings module references and related code

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Having trouble? Get help in the official [Saucebase Discord](https://discord.gg/
 | Module | Version | Description |
 | ------ | ------- | ----------- |
 | [auth](https://github.com/saucebase-dev/auth) | [![auth version](https://img.shields.io/packagist/v/saucebase/auth.svg?label=%20)](https://github.com/saucebase-dev/auth) | Authentication, social login, email verification, and admin impersonation |
-| [settings](https://github.com/saucebase-dev/settings) | [![settings version](https://img.shields.io/packagist/v/saucebase/settings.svg?label=%20)](https://github.com/saucebase-dev/settings) | User profile management, avatar uploads, and password changes |
 | [billing](https://github.com/saucebase-dev/billing) | [![billing version](https://img.shields.io/packagist/v/saucebase/billing.svg?label=%20)](https://github.com/saucebase-dev/billing) | Subscriptions, checkout sessions, and payment processing |
 | [announcements](https://github.com/saucebase-dev/announcements) | [![announcements version](https://img.shields.io/packagist/v/saucebase/announcements.svg?label=%20)](https://github.com/saucebase-dev/announcements) | Site-wide announcement banners with scheduling and dismissal support |
 | [roadmap](https://github.com/saucebase-dev/roadmap) | [![roadmap version](https://img.shields.io/packagist/v/saucebase/roadmap.svg?label=%20)](https://github.com/saucebase-dev/roadmap) | Feature requests, voting, and public product roadmap |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,9 +10,6 @@ includes:
     auth:
         taskfile: ./modules/auth/Taskfile.yml
         optional: true
-    settings:
-        taskfile: ./modules/settings/Taskfile.yml
-        optional: true
     billing:
         taskfile: ./modules/billing/Taskfile.yml
         optional: true

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
         "saucebase/billing": "Subscription management and payment processing via Stripe with checkout, billing portal, and webhooks",
         "saucebase/demo": "Demo module with a variety of example pages and components to jumpstart your development",
         "saucebase/roadmap": "Public roadmap with feature requests, voting, moderation, and a Filament admin panel",
-        "saucebase/settings": "Account settings pages for managing profile info, avatar, password, and connected social accounts",
         "saucebase/themes": "Visual theme editor for colors, fonts, radius, and shadows — baked into CSS with no runtime overhead",
         "saucebase/blog": "Full-featured blog with posts, categories, cover images, SEO metadata, and a Filament admin panel for content management"
     },

--- a/module-loader.js
+++ b/module-loader.js
@@ -134,7 +134,7 @@ export async function collectModulePlaywrightConfigs() {
  *
  * @example
  * const langPaths = await collectModuleLangPaths();
- * // Returns: ['modules/auth/lang', 'modules/settings/lang', ...]
+ * // Returns: ['modules/auth/lang', 'modules/billing/lang', ...]
  */
 export async function collectModuleLangPaths() {
     const langPaths = [];

--- a/resources/js/react/components/ui/saucebase/index.ts
+++ b/resources/js/react/components/ui/saucebase/index.ts
@@ -11,7 +11,6 @@ import {
     Megaphone,
     Newspaper,
     Palette,
-    Settings2,
     Webhook,
 } from 'lucide-react';
 
@@ -94,23 +93,8 @@ export const modules: Module[] = [
             'Social Login',
             'Email Verification',
             'Impersonation',
-        ],
-    },
-    {
-        id: 'settings',
-        title: 'Settings',
-        description:
-            'Account settings pages for managing profile info, avatar, password, and connected social accounts.',
-        icon: Settings2,
-        color: '--color-gray-500',
-        badge: BADGE_SOON,
-        href: null,
-        frameworks: ['vue'] as const,
-        features: [
-            'Profile Info',
-            'Avatar Upload',
+            'Profile & Avatar',
             'Password Change',
-            'Connected Accounts',
         ],
     },
     {

--- a/resources/js/vue/components/ui/saucebase/index.ts
+++ b/resources/js/vue/components/ui/saucebase/index.ts
@@ -13,7 +13,6 @@ import {
     Megaphone,
     Newspaper,
     Palette,
-    Settings2,
     Webhook,
 } from '@lucide/vue';
 
@@ -84,25 +83,8 @@ export const modules = [
             () => trans('Social Login'),
             () => trans('Email Verification'),
             () => trans('Impersonation'),
-        ],
-    },
-    {
-        id: 'settings',
-        title: () => trans('Settings'),
-        description: () =>
-            trans(
-                'Account settings pages for managing profile info, avatar, password, and connected social accounts.',
-            ),
-        icon: Settings2,
-        color: '--color-sky-500',
-        badge: null,
-        href: 'https://saucebase-dev.github.io/docs/modules/settings',
-        frameworks: ['vue'] as const,
-        features: [
-            () => trans('Profile Info'),
-            () => trans('Avatar Upload'),
+            () => trans('Profile & Avatar'),
             () => trans('Password Change'),
-            () => trans('Connected Accounts'),
         ],
     },
     {

--- a/tests/Support/TestFixtures.php
+++ b/tests/Support/TestFixtures.php
@@ -9,42 +9,80 @@ use Illuminate\Support\Str;
 
 class TestFixtures
 {
+    /**
+     * Password for the shared, fixed-email accounts.
+     *
+     * Fixed rather than random because these rows are created once and then only
+     * ever read. See seedSharedAccounts().
+     */
+    public const SHARED_PASSWORD = 'e2e-shared-password';
+
+    /**
+     * Accounts referenced by fixed email across specs (billing, mainly).
+     *
+     * @var array<string, string>
+     */
+    private const SHARED_ACCOUNTS = [
+        'subscriber@example.com' => 'Subscriber User',
+        'cancelled@example.com' => 'Cancelled User',
+    ];
+
+    /**
+     * Create the shared, fixed-email accounts.
+     *
+     * Called once from the Playwright `database.setup` project, which runs on its
+     * own before any worker starts. Doing it here — rather than per test — is what
+     * makes parallel workers safe: `syncRoles()` is a detach-then-attach, so two
+     * workers running it against the same user race into a duplicate primary key
+     * on `model_has_roles`, and a per-test random password meant one worker could
+     * overwrite the credentials another worker was still logging in with.
+     */
+    public static function seedSharedAccounts(): void
+    {
+        foreach (self::SHARED_ACCOUNTS as $email => $name) {
+            $account = User::firstOrCreate(
+                ['email' => $email],
+                [
+                    'name' => $name,
+                    'password' => Hash::make(self::SHARED_PASSWORD),
+                    'email_verified_at' => now(),
+                ]
+            );
+
+            $account->syncRoles([Role::USER->value]);
+        }
+    }
+
+    /**
+     * Credentials for a single test.
+     *
+     * The admin and user accounts are created fresh per call, so each test — and
+     * so each worker — gets its own rows with factory-unique emails. The shared
+     * accounts are only read; they are provisioned by seedSharedAccounts().
+     *
+     * @return array<string, array{email: string, password: string}>
+     */
     public static function credentials(): array
     {
         $password = Str::password(12, symbols: false);
 
         $admin = User::factory()->create([
-            'password'          => Hash::make($password),
+            'password' => Hash::make($password),
             'email_verified_at' => now(),
         ]);
         $admin->syncRoles([Role::ADMIN->value]);
 
         $user = User::factory()->create([
-            'password'          => Hash::make($password),
+            'password' => Hash::make($password),
             'email_verified_at' => now(),
         ]);
         $user->syncRoles([Role::USER->value]);
 
-        // Fixed emails so billing-related tests can reference these accounts consistently.
-        $subscriber = User::firstOrCreate(
-            ['email' => 'subscriber@example.com'],
-            ['name' => 'Subscriber User', 'email_verified_at' => now()]
-        );
-        $subscriber->update(['password' => Hash::make($password)]);
-        $subscriber->syncRoles([Role::USER->value]);
-
-        $cancelled = User::firstOrCreate(
-            ['email' => 'cancelled@example.com'],
-            ['name' => 'Cancelled User', 'email_verified_at' => now()]
-        );
-        $cancelled->update(['password' => Hash::make($password)]);
-        $cancelled->syncRoles([Role::USER->value]);
-
         return [
-            'admin'      => ['email' => $admin->email,       'password' => $password],
-            'user'       => ['email' => $user->email,         'password' => $password],
-            'subscriber' => ['email' => $subscriber->email,   'password' => $password],
-            'cancelled'  => ['email' => $cancelled->email,    'password' => $password],
+            'admin' => ['email' => $admin->email, 'password' => $password],
+            'user' => ['email' => $user->email, 'password' => $password],
+            'subscriber' => ['email' => 'subscriber@example.com', 'password' => self::SHARED_PASSWORD],
+            'cancelled' => ['email' => 'cancelled@example.com', 'password' => self::SHARED_PASSWORD],
         ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,10 +6,26 @@ use App\Enums\Role;
 use App\Models\User;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\Vite;
 
 abstract class TestCase extends BaseTestCase
 {
     protected $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Point Vite at a hot file that never exists, so tests always resolve assets
+        // through the build manifest — exactly as CI does.
+        //
+        // Laravel's Vite helper short-circuits to the dev server whenever public/hot
+        // is present, skipping the manifest entirely. That file exists while
+        // `npm run dev` is running, and the Playwright web server can leave a stale
+        // one behind. Either way it silently hides missing-manifest-entry failures
+        // locally and lets them through to CI.
+        Vite::useHotFile(storage_path('framework/testing/vite-hot-file-that-never-exists'));
+    }
 
     /** @return User&Authenticatable */
     protected function createUser(): User

--- a/tests/e2e/database.setup.ts
+++ b/tests/e2e/database.setup.ts
@@ -4,4 +4,11 @@ setup('setup the database', async ({ laravel }) => {
     await laravel.artisan('migrate:fresh');
     await laravel.artisan('db:seed');
     await laravel.artisan('modules:seed');
+
+    // Shared fixed-email accounts are created here, once, rather than per test.
+    // This project runs on its own before any worker starts, so the writes cannot
+    // race. See Tests\Support\TestFixtures::seedSharedAccounts().
+    await laravel.callFunction(
+        'Tests\\Support\\TestFixtures::seedSharedAccounts',
+    );
 });

--- a/tests/e2e/fixtures/index.ts
+++ b/tests/e2e/fixtures/index.ts
@@ -1,6 +1,6 @@
 import { loginAs as doLoginAs } from '@e2e/helpers/auth';
 import { expect } from '@playwright/test';
-import { test as base, Laravel } from '@saucebase/laravel-playwright';
+import { test as base } from '@saucebase/laravel-playwright';
 
 export type UserCredential = { email: string; password: string };
 
@@ -16,13 +16,6 @@ export const test = base.extend<{
     credentials: TestCredentials;
     loginAs: (user: UserCredential) => Promise<void>;
 }>({
-    laravel: async (
-        { laravel }: { laravel: Laravel },
-        use: (arg: Laravel) => Promise<void>,
-    ) => {
-        await laravel.config('mail.default', 'log');
-        await use(laravel);
-    },
     credentials: async ({ laravel }, use) => {
         const creds = await laravel.callFunction<TestCredentials>(
             'Tests\\Support\\TestFixtures::credentials',


### PR DESCRIPTION
This pull request removes the `settings` module from the codebase and refactors related test fixtures to improve reliability and parallelism. It also introduces a new approach for managing shared test accounts, ensuring consistent credentials across tests and CI environments.

**Module removal and cleanup:**
- Removed all references to the `settings` module across documentation, configuration, and UI code, including `README.md`, `Taskfile.yml`, `composer.json`, and both React and Vue module lists. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61)`, `[[2]](diffhunk://#diff-cd2d359855d0301ce190f1ec3b4c572ea690c83747f6df61c9340720e3d2425eL13-L15)`, `[[3]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L55)`, `[[4]](diffhunk://#diff-f31b469dff43b5e07746522a74df4670c3432929e8d246a4595384297c28dec3L97-L113)`, `[[5]](diffhunk://#diff-52b7304eee456199af0b90e5dd8be355480aaea13b9db2c260fc4a839760fe1cL87-L105)`, `[[6]](diffhunk://#diff-f31b469dff43b5e07746522a74df4670c3432929e8d246a4595384297c28dec3L14)`, `[[7]](diffhunk://#diff-52b7304eee456199af0b90e5dd8be355480aaea13b9db2c260fc4a839760fe1cL16)`, `[[8]](diffhunk://#diff-b6244d84a06b931a15e0e0dcfbba63f6df8ac0b2558b15304c86a218c68f1560L137-R137)`)

**Test fixture improvements:**
- Centralized creation of shared, fixed-email test accounts (e.g., `subscriber@example.com`) into a new `seedSharedAccounts()` method in `TestFixtures`, using a fixed password, and updated `credentials()` to reference these accounts. (`[[1]](diffhunk://#diff-999676108a4d89b2cdf5c8eb297a306e43275c247b1d86fb00f8d1621977d46eR12-R64)`, `[[2]](diffhunk://#diff-999676108a4d89b2cdf5c8eb297a306e43275c247b1d86fb00f8d1621977d46eL28-R85)`)
- Updated the Playwright database setup script to call `seedSharedAccounts()` once before any test workers start, preventing race conditions and ensuring consistent test data. (`[tests/e2e/database.setup.tsR7-R13](diffhunk://#diff-b08a318c8d0b5691cfa6a7fcbd94a33c3013bbfd2b22890c4a786ce9b318e46cR7-R13)`)

**Test environment reliability:**
- Forced Laravel’s Vite asset helper to always use the build manifest during tests by pointing it at a non-existent hot file, preventing local/CI inconsistencies due to stale or present hot files. (`[tests/TestCase.phpR9-R29](diffhunk://#diff-abf1fa77a19f720052b75bc802df0260157b9064d8c3c12a80794f01e9acc065R9-R29)`)

**Test code cleanup:**
- Removed unused imports and redundant Playwright test fixture setup related to Laravel configuration, simplifying the test fixture code. (`[[1]](diffhunk://#diff-235299540bae84059191988c9e4c0b7a56e011bf30fb5f110b6bb1e89df9df4aL3-R3)`, `[[2]](diffhunk://#diff-235299540bae84059191988c9e4c0b7a56e011bf30fb5f110b6bb1e89df9df4aL19-L25)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Features**
  - Auth module feature lists now include profile and avatar management.

- **Changes**
  - Removed the Settings module from the documented and configured module listings.
  - Removed the related optional package suggestion and unused interface icons.

- **Testing**
  - Standardized shared test accounts and credentials.
  - Tests now consistently resolve frontend assets through the build manifest.
  - Simplified end-to-end test fixtures by removing the Laravel application fixture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->